### PR TITLE
Use M-h instead of M-H for comint-bol.

### DIFF
--- a/ergoemacs-themes.el
+++ b/ergoemacs-themes.el
@@ -606,7 +606,7 @@
   (global-set-key (kbd "M-H") 'ergoemacs-end-of-line-or-what)
   ;; Mode specific movement
   (define-key eshell-mode-map (kbd "M-h") 'eshell-bol)
-  (define-key comint-mode-map (kbd "M-H") 'comint-bol))
+  (define-key comint-mode-map (kbd "M-h") 'comint-bol))
 
 (ergoemacs-theme-component move-and-transpose-lines ()
   "Move Current line/selection down or up with Alt+up or Alt+down"


### PR DESCRIPTION
This is for consistency with the keyboard map of ergoemacs when in shell-mode.  M-h should go to the beginning of the line, M-H to the end of the line.
