### PR TITLE
Emacs26 fixes

### DIFF
--- a/ergoemacs-functions.el
+++ b/ergoemacs-functions.el
@@ -2367,7 +2367,7 @@ exists and opens it in emacs, if possible."
     ;; Tilde (ñãõÑÃÕ)
     (?\361 . ?n)(?\343 . ?a)(?\365 . ?o)(?\321 . ?N)(?\303 . ?A)(?\325 . ?O)
     (?\337 . "ss")                      ; S-zed (Beta) (ß)
-    (?\253 . ?")(?\273 . ?")            ; Guillemets -> double quotes («»)
+    (?\253 . ?\")(?\273 . ?\")          ; Guillemets -> double quotes («»)
     (?\346 . "ae")(?\306 . "AE")        ; ae, AE (æÆ)
     (?\370 . ?o)(?\330 . ?O)            ; Slashed O (øØ)
     (?\260 . ?@)(?\345 . ?a)(?\305 . ?A) ; Angstrom (degree) (°åÅ)

--- a/ergoemacs-map-properties.el
+++ b/ergoemacs-map-properties.el
@@ -651,7 +651,7 @@ These keymaps are saved in `ergoemacs-map-properties--hook-map-hash'."
           (ergoemacs-timing ergoemacs-create-global
             (let* ((emacs-exe (ergoemacs-emacs-exe))
                    (default-directory (expand-file-name (file-name-directory (locate-library "ergoemacs-mode"))))
-                   (cmd (format "%s -L %s --batch --load \"ergoemacs-mode\" -Q --eval \"(ergoemacs-map-properties--default-global-gen) (kill-emacs)\"" emacs-exe default-directory)))
+                   (cmd (format "%s -L %s --batch --load \"ergoemacs-mode\" -Q --eval \"(progn (ergoemacs-map-properties--default-global-gen) (kill-emacs))\"" emacs-exe default-directory)))
               (message "%s" (shell-command-to-string cmd))
               (ergoemacs-map-properties--get-original-global-map))))))))
 


### PR DESCRIPTION
Trunk GNU Emacs with ergoemacs-mode for some time was going into
endless loop on load due to improperly sending 2 forms for evaluation
to the outside emacs process (versions 25 and below seem more tolerant
and do the right thing, but).  Here's *Messages* snippet which is
repeated until C-g is invoked:

> Cache reset before loading.
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-command-loop.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-advice.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-component.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-debug.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-functions.el (source)...
> Loading ‘ergoemacs-functions’: unescaped character literals `?"' detected!
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-key-description.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-layouts.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-lib.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-map.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-map-properties.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-mapkeymap.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-theme-engine.el (source)...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-translate.el (source)...
> Loading two-column...
> Loading /home/andrey/.emacs.d/elpa/ergoemacs-mode-20170723.1921/ergoemacs-themes.el (source)...
> Warning (ergoemacs): Could not find global map information
> Loading /home/andrey/.emacs.d/recentf...
> Cleaning up the recentf list...
> Cleaning up the recentf list...done (0 removed)
> Ergoemacs-mode turned ON (us:standard).
> Started ‘ergoemacs-mode’. Total startup time 3.566119 (Load: 3.073180, Initialize:0.492938)
> Trailing garbage following expression:  (kill-emacs)

This is fixed with a87fae7.

The second commit 4e188fd addresses the warning from above where
double quotes are improperly escaped.
