### PR TITLE
Add hooks to ergoemacs-map-properties--modify-run-mode-hooks-excluded

### DIFF
--- a/ergoemacs-map-properties.el
+++ b/ergoemacs-map-properties.el
@@ -438,7 +438,8 @@ Save information about what HOOK is running function FN."
 
 
 (defvar ergoemacs-map-properties--modify-run-mode-hooks-excluded
-  '(font-lock-mode-hook emojify-emojify-mode-line mu4e-update-mail-and-index)
+  '(font-lock-mode-hook emojify-emojify-mode-line mu4e-update-mail-and-index
+    change-major-mode-hook after-change-major-mode-hook)
   "List of hooks where keymaps should not be modified.")
 
 (defun ergoemacs-map-properties--modify-run-mode-hooks-p (hook)


### PR DESCRIPTION
Specifically, `change-major-mode-hook` and `after-change-major-mode-hook`. Before, ErgoEmacs would interpret them as mode hooks, because their names end in “mode-hook.” (This fixes a problem I was having with `persp-mode`.)