### PR TITLE
Fix typos (dispaly -> display)

### DIFF
--- a/ergoemacs-key-description.el
+++ b/ergoemacs-key-description.el
@@ -123,7 +123,7 @@ This assumes `ergoemacs-display-unicode-characters' is non-nil.  When
     alt-char))
 
 (defun ergoemacs-key-description--unicode-char (&rest chars)
-  "Return the first dispalyable character in CHARS.
+  "Return the first displayable character in CHARS.
 This uses `ergoemacs-key-description--unicode-char--internal'"
   (if ergoemacs-use-unicode-symbols
       (let* ((char-list chars)

--- a/ergoemacs-mode.el
+++ b/ergoemacs-mode.el
@@ -839,7 +839,7 @@ Valid values are:
   :initialize #'custom-initialize-default
   :group 'ergoemacs-mode)
 
-(defgroup ergoemacs-dispaly nil
+(defgroup ergoemacs-display nil
   "Display Options for `ergoemacs-mode'."
   :group 'ergoemacs-mode)
 


### PR DESCRIPTION
This typo shows up in the customize screen and help for ergoemacs-key-description--unicode-char.