### PR TITLE
Fix command-loop errors

### DIFF
--- a/ergoemacs-mapkeymap.el
+++ b/ergoemacs-mapkeymap.el
@@ -194,7 +194,9 @@ them to be masked when mapping over the keymap."
              (cond
               ((consp event)
                (ergoemacs-map-set-char-table-range
-                (or (and prefix (lookup-key flat-keymap prefix))
+                (or (and prefix
+                         (let ((prefix-lookup (lookup-key flat-keymap prefix)))
+                           (if (listp prefix-lookup) prefix-lookup)))
                     flat-keymap) event item))
               (t
                (define-key flat-keymap key item)


### PR DESCRIPTION
The problem was that mapkeymap was looking for a prefix in a keymap
and assuming that the result was a list.  This will fail when invoking
'term', because it has a keymap with a lot of elements specified as

  #^^[3 0 term-send-raw-meta term-send-raw-meta ...

We now check explicitly for whether the result is a list.

Fixes #493, #378, and #455.