### PR TITLE
Preserve the behavior of 'space' when rebinding inside a minibuffer

### DIFF
--- a/ergoemacs-map.el
+++ b/ergoemacs-map.el
@@ -1023,7 +1023,12 @@ When INI is non-nil, add conditional maps to `minor-mode-map-alist'."
 	 (use-local-map (ergoemacs current-local-map))
 	 (setq ergoemacs-map--breadcrumb ""))
        (when (and (minibufferp) ergoemacs-read-from-minibuffer-map)
-	 (use-local-map (ergoemacs ergoemacs-read-from-minibuffer-map))
+         ;; Preserve bindings for space, such as when completing a filename
+         (if (and (equal (key-binding " ") 'self-insert-command))
+             (use-local-map (list 'keymap
+                                  '(32 . self-insert-command) ;; space==32
+                                  (ergoemacs ergoemacs-read-from-minibuffer-map)))
+           (use-local-map (ergoemacs ergoemacs-read-from-minibuffer-map)))
 	 (setq ergoemacs-read-from-minibuffer-map nil
 	       ergoemacs-map--breadcrumb ""))
        ;; Run deferred "hooks"


### PR DESCRIPTION
In minibuffers, the usual binding for 'space' is 'complete-word.  When
completing filenames, it is overriden to allow literal spaces.  This
fix preserves that override.

Fixes #471 