### PR TITLE
Remove some dead code and address various compiler warnings

### DIFF
--- a/ergoemacs-advice.el
+++ b/ergoemacs-advice.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-advice.el --- Ergoemacs advices -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-advice.el
 ;; Description:
@@ -35,6 +35,7 @@
 
 (require 'mouse)
 (require 'nadvice)
+(require 'ergoemacs-command-loop)
 
 (defvar ergoemacs-mode)
 (defvar ergoemacs-keymap)
@@ -94,6 +95,7 @@ TYPE is the type of translation installed."
             (when (memq 'down (event-modifiers last-command-event))
               current-prefix-arg)))))
 
+(defvar ergoemacs--temporary-disable)
 (defun ergoemacs-advice-undefined (orig-fun)
   "Allow `ergoemacs-mode' to display keys, and intercept ending <apps> keys."
   (if (and ergoemacs-mode (not ergoemacs--temporary-disable))

--- a/ergoemacs-cua.el
+++ b/ergoemacs-cua.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-cua.el --- Keyboard keybinding translation -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-cua.el
 ;; Description:
@@ -61,21 +61,22 @@
 
 (defvar ergoemacs--prefix-override-keymap
   (let ((map (make-sparse-keymap)))
-    (define-key map [(control x)] 'ergoemacs--prefix-override-handler)
-    (define-key map [(control c)] 'ergoemacs--prefix-override-handler)
+    (define-key map [(control x)] #'ergoemacs--prefix-override-handler)
+    (define-key map [(control c)] #'ergoemacs--prefix-override-handler)
     map)
   "Prefix override keymap.")
 
 (defvar ergoemacs--ena-prefix-repeat-keymap nil
-  "Variable that states that `ergoemacs-mode' is in the repeat phase, immediately after using the prefix key.")
+  "Non-nil if `ergoemacs-mode' is in the repeat phase,
+I.e. immediately after using the prefix key.")
 
 (defvar ergoemacs--prefix-repeat-keymap
   (let ((map (make-sparse-keymap)))
-    (define-key map [(control x) (control x)] 'ergoemacs--prefix-repeat-handler)
-    (define-key map [(control c) (control c)] 'ergoemacs--prefix-repeat-handler)
+    (define-key map [(control x) (control x)] #'ergoemacs--prefix-repeat-handler)
+    (define-key map [(control c) (control c)] #'ergoemacs--prefix-repeat-handler)
     (dolist (key '(up down left right home end next prior))
-      (define-key map (vector '(control x) key) 'ergoemacs--prefix-cut-handler)
-      (define-key map (vector '(control c) key) 'ergoemacs--prefix-copy-handler)))
+      (define-key map (vector '(control x) key) #'ergoemacs--prefix-cut-handler)
+      (define-key map (vector '(control c) key) #'ergoemacs--prefix-copy-handler)))
   "Prefix repeat keymap.")
 
 
@@ -109,7 +110,7 @@ enabled."
 This is also used to select the region keymaps.")
 
 (defvar ergoemacs--ena-prefix-override-keymap nil
-  "Variable that tels the `ergoemacs-mode' of the overide step is active.
+  "Non-nil if `ergoemacs-mode's override step is active.
 
 This override is enabled for active regions before the copy and paste are enabled.")
 

--- a/ergoemacs-debug.el
+++ b/ergoemacs-debug.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-debug.el --- Ergoemacs map interface -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-debug.el
 ;; Description:
@@ -58,7 +58,7 @@
   "Ergoemacs debugging heading."
   (ergoemacs-debug (concat "** "
                            (condition-case err
-                               (apply 'format arg)
+                               (apply #'format arg)
                              (error (format "Bad format string: %s (%s)" arg err)))))
   (ergoemacs-debug "Time Since Start ergoemacs-mode: %1f sec" (- (float-time) ergoemacs-debug-heading-start-time))
   (ergoemacs-debug "Time Since Last Heading: %1f sec" (- (float-time) ergoemacs-debug-heading-last-time))
@@ -79,7 +79,7 @@
           (format "%s\n%s"
                   ergoemacs-debug
                   (condition-case err
-                      (apply 'format arg)
+                      (apply #'format arg)
                     (error (format "Bad Format String: %s (%s)" arg err)))))))
 
 (defun ergoemacs-debug-clear ()

--- a/ergoemacs-layouts.el
+++ b/ergoemacs-layouts.el
@@ -1,6 +1,6 @@
-;;; ergoemacs-layouts.el --- keyboard layouts for ErgoEmacs -* lexical-binding: t -*-
+;;; ergoemacs-layouts.el --- keyboard layouts for ErgoEmacs -*- lexical-binding: t -*-
 
-;; Copyright (C) 2013-2021 Free Software Foundation, Inc.
+;; Copyright (C) 2013-2023 Free Software Foundation, Inc.
 
 ;; Maintainer: Matthew L. Fidler
 ;; Keywords: convenience
@@ -415,7 +415,7 @@ If LAYOUT is unspecified, use `ergoemacs-keyboard-layout'."
     ,@(mapcar
               (lambda(elt)
                 `(const :tag ,elt :value ,elt))
-              (sort (ergoemacs-layouts--list t) 'string<))))
+              (sort (ergoemacs-layouts--list t) #'string<))))
 
 (defun ergoemacs-layouts--custom-documentation (&optional lays ini)
   "Get a documentation list of all known layouts.
@@ -424,7 +424,7 @@ LAYS is the layouts being processed.
 
 If INI is non-nil, create information about the autohotkey ini
 file."
-  (let ((lays (or lays (sort (ergoemacs-layouts--list t) 'string<))))
+  (let ((lays (or lays (sort (ergoemacs-layouts--list t) #'string<))))
     (mapconcat
      (lambda(lay)
        (let* ((variable (intern (concat "ergoemacs-layout-" lay)))
@@ -543,8 +543,7 @@ Otherwise, `ergoemacs-mode' will try to adjust based on your layout."
 
 when BASE is non-nil, the regular expression shows the regular
 expression matching the base layout."
-  (let ((reg (regexp-opt (ergoemacs-layouts--list t) t))
-        (f1 "[\"`']\\(%s\\)[\"`']")
+  (let ((f1 "[\"`']\\(%s\\)[\"`']")
         (f2 "Base Layout: \\(%s\\)"))
     (format (cond
              (base f2)
@@ -578,14 +577,10 @@ LAYOUT can be either a symbol or string."
          (s (intern (concat "ergoemacs-layout-" layout)))
          (sv (and (boundp s) (symbol-value s)))
          (el-file (find-lisp-object-file-name s 'defvar))
-         (alias (condition-case nil
-                    (indirect-variable s)
-                  (error s)))
          (doc (or (documentation-property
                    s 'variable-documentation)
                   (documentation-property
                    s 'variable-documentation)))
-         pt
          png svg)
     (unless (featurep 'quail)
       (require 'quail))
@@ -653,7 +648,7 @@ LAYOUT can be either a symbol or string."
           ;; Return the text we displayed.
           (buffer-string))))))
 
-(defalias 'describe-ergoemacs-layout 'ergoemacs-layout-describe)
+(defalias 'describe-ergoemacs-layout #'ergoemacs-layout-describe)
 
 (provide 'ergoemacs-layouts)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/ergoemacs-map.el
+++ b/ergoemacs-map.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-map.el --- Ergoemacs map interface -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-map.el
 ;; Description:
@@ -183,43 +183,43 @@ save the infromationin the `ergoemacs-map--alist' hash."
   (let ((old-breadcrumb ergoemacs-map--breadcrumb)
         breadcrumb-base type old-len)
     (if (and symbol (setq old-len (ergoemacs-gethash symbol ergoemacs-map--alist))
-             (= (length alist) old-len)) alist
+             (= (length alist) old-len))
+        alist
       (when symbol
         (puthash symbol (length alist) ergoemacs-map--alist)
         (setq breadcrumb-base (format "%s:%s" old-breadcrumb symbol)))
       (setq ergoemacs-map--alist-atom-symbol-reset-when-volatile symbol)
       (prog1
-	  (unwind-protect
-	      (prog1 (mapcar
-		      (lambda(elt)
-			(cond
-			 ;; ((not (ergoemacs-sv (car elt)))
-			 ;;  ;; not enabled, ignore any changes to this map...?
-			 ;;  elt)
-			 ((eq (car elt) 'ergoemacs-mode) elt)
-			 ((and (not (setq type (ergoemacs (cdr elt) :installed-p))) ergoemacs-mode)
-			  ;; Install `ergoemacs-mode' into the keymap
-			  (ergoemacs-map--alist-atom (car elt) (cdr elt) breadcrumb-base))
-			 ((not type)
-			  ;; Install `ergoemacs-mode' user protection into the
-			  ;; keymap.
-			  (ergoemacs-map--alist-atom (car elt) (cdr elt) breadcrumb-base t))
-			 ((eq :cond-map type)
-			  ;; Don't change conditional maps.  Change in alists...?
-			  elt)
-			 ((and ergoemacs-mode (eq :protected-p type))
-			  ;; Change protection into full ergoemacs-mode installation
-			  (ergoemacs-map--alist-atom (car elt) (ergoemacs (cdr elt) :original) breadcrumb-base))
-			 ((eq :protected-p type)
-			  ;; Already protected.
-			  elt)
-			 ((and ergoemacs-mode type)
-			  ;; Already installed
-			  elt)
-			 ((and (not ergoemacs-mode) type)
-			  (ergoemacs-map--alist-atom (car elt) (ergoemacs (cdr elt) :original-user) breadcrumb-base))))
-		      alist)
-		(setq ergoemacs-map--breadcrumb old-breadcrumb)))
+	  (mapcar
+	   (lambda(elt)
+	     (cond
+	      ;; ((not (ergoemacs-sv (car elt)))
+	      ;;  ;; not enabled, ignore any changes to this map...?
+	      ;;  elt)
+	      ((eq (car elt) 'ergoemacs-mode) elt)
+	      ((and (not (setq type (ergoemacs (cdr elt) :installed-p))) ergoemacs-mode)
+	       ;; Install `ergoemacs-mode' into the keymap
+	       (ergoemacs-map--alist-atom (car elt) (cdr elt) breadcrumb-base))
+	      ((not type)
+	       ;; Install `ergoemacs-mode' user protection into the
+	       ;; keymap.
+	       (ergoemacs-map--alist-atom (car elt) (cdr elt) breadcrumb-base t))
+	      ((eq :cond-map type)
+	       ;; Don't change conditional maps.  Change in alists...?
+	       elt)
+	      ((and ergoemacs-mode (eq :protected-p type))
+	       ;; Change protection into full ergoemacs-mode installation
+	       (ergoemacs-map--alist-atom (car elt) (ergoemacs (cdr elt) :original) breadcrumb-base))
+	      ((eq :protected-p type)
+	       ;; Already protected.
+	       elt)
+	      ((and ergoemacs-mode type)
+	       ;; Already installed
+	       elt)
+	      ((and (not ergoemacs-mode) type)
+	       (ergoemacs-map--alist-atom (car elt) (ergoemacs (cdr elt) :original-user) breadcrumb-base))))
+	   alist)
+	(setq ergoemacs-map--breadcrumb old-breadcrumb)
 	(setq ergoemacs-map--alist-atom-symbol-reset-when-volatile nil)))))
 
 (defvar ergoemacs-map--alists (make-hash-table))

--- a/ergoemacs-mapkeymap.el
+++ b/ergoemacs-mapkeymap.el
@@ -136,7 +136,7 @@ them to be masked when mapping over the keymap."
                            (make-keymap))))
         composed-list
         parent
-        calc-parent-p
+        ;; calc-parent-p
         prefix-map
         tmp)
     (when (not prefix)
@@ -164,9 +164,9 @@ them to be masked when mapping over the keymap."
              (when function
                (funcall function key 'ergoemacs-prefix))
              (ergoemacs-map-keymap--map-submap item function original key flat-keymap nil-keys)
-             (unless calc-parent-p
+             ;; (unless calc-parent-p
                (setq composed-list (ergoemacs :composed-list keymap)
-                     parent (keymap-parent keymap)))
+                     parent (keymap-parent keymap)) ;;)
              (if composed-list
                  (dolist (map composed-list)
                    (when (and (ergoemacs-keymapp map)

--- a/ergoemacs-mode.el
+++ b/ergoemacs-mode.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-mode.el --- Emacs mode based on common modern interface and ergonomics. -*- lexical-binding: t -*-
 
-;; Copyright © 2007-2010, 2012-2021  Free Software Foundation, Inc.
+;; Copyright © 2007-2023  Free Software Foundation, Inc.
 
 ;; Author: Xah Lee <xah@xahlee.org>
 ;;         David Capello <davidcapello@gmail.com>
@@ -305,10 +305,10 @@ Home page URL `http://ergoemacs.github.io/'
 
 The `execute-extended-command' is now \\[execute-extended-command].
 "
-  nil
   :lighter " ErgoEmacs"
   :global t
   :group 'ergoemacs-mode
+  ;; FIXME: This var is only ever set: never used!
   (setq ergoemacs-mode--start-p t)
   (if ergoemacs-mode
       (progn
@@ -335,7 +335,7 @@ The `execute-extended-command' is now \\[execute-extended-command].
          ((string-equal ergoemacs-theme "reduction")
           (ergoemacs-setup-override-keymap))
          (t (ergoemacs-setup-override-keymap)))
-        (setq ergoemacs-require--ini-p t
+        (setq ergoemacs-require--ini-p t ;FIXME: Unused?
               ergoemacs-send-keys-term  ergoemacs-mode-send-emacs-keys)
         
         (message "Ergoemacs-mode turned ON (%s)." ergoemacs-keyboard-layout))
@@ -432,13 +432,12 @@ This is structured by valid keyboard layouts for
 basic ergoemacs functionality.  For example, if you want M-t to
 transpose words instead of running completion, call
 
-  (ergoemacs-define-key ergoemacs-override-keymap (kbd \"M-t\") 'transpose-words)
+  (ergoemacs-define-key ergoemacs-override-keymap (kbd \"M-t\") #\\='transpose-words)
 
-after initializing ergoemacs-mode.
-")
+after initializing ergoemacs-mode.")
 
 (defvar ergoemacs-mark-active-keymap (let ((map (make-sparse-keymap)))
-                                       (define-key map (kbd "TAB") 'indent-region)
+                                       (define-key map (kbd "TAB") #'indent-region)
                                        (define-key map [(shift control x)] 'ergoemacs--shift-control-x-prefix)
                                        (define-key map [(shift control c)] 'ergoemacs--shift-control-c-prefix)
                                        map)
@@ -470,13 +469,14 @@ after initializing ergoemacs-mode.
           (ergoemacs-mode-regular . ,ergoemacs-override-keymap)
           (ergoemacs-mode-regular . ,ergoemacs-keymap)
           (ergoemacs-mode-send-emacs-keys . ,ergoemacs--send-emacs-keys-map)))
-  (add-hook 'emulation-mode-map-alists ergoemacs-override-alist)
+  (add-to-list 'emulation-mode-map-alists ergoemacs-override-alist)
   (advice-add 'undefined :around #'ergoemacs-advice-undefined)
   (advice-add 'read-key :around #'ergoemacs-read-key))
 
 (defun ergoemacs-remove-override-keymap ()
   "Remove `ergoemacs-mode' keymaps."
-  (remove-hook 'emulation-mode-map-alists 'ergoemacs-override-alist)
+  (setq emulation-mode-map-alists
+        (delq ergoemacs-override-alist emulation-mode-map-alists))
   (advice-remove 'undefined #'ergoemacs-advice-undefined)
   (advice-remove 'read-key #'ergoemacs-read-key))
 

--- a/ergoemacs-test.el
+++ b/ergoemacs-test.el
@@ -512,27 +512,6 @@ Part of addressing Issue #147."
     ;; Test M-m -> ^m -> RET
     (should (string= "RET" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-m" t) 0) :ctl-to-alt)))))))
 
-(ert-deftest ergoemacs-test-input-methods ()
-  "Make sure that `ergoemacs-mode' works with input methods."
-  :tags '(:translate)
-  (ergoemacs-test-layout
-   :layout "colemak"
-   :macro "arst"
-   (save-excursion
-     (switch-to-buffer (get-buffer-create "*ergoemacs-test*"))
-     (delete-region (point-min) (point-max))
-     (set-input-method "greek")
-     (message "%s" current-input-method)
-     (ergoemacs-command-loop--internal "arst")
-     (should (string= "αρστ" (buffer-string)))
-     (quail-set-keyboard-layout "colemak")
-     (delete-region (point-min) (point-max))
-     (ergoemacs-command-loop--internal "arst")
-     (quail-set-keyboard-layout "standard")
-     (should (string= "ασδφ" (buffer-string)))
-     (set-input-method nil)
-     (kill-buffer (current-buffer)))))
-
 (ert-deftest ergoemacs-test-table-insert ()
   "Tests that table can insert without hanging emacs."
   :tags '(:table)

--- a/ergoemacs-test.el
+++ b/ergoemacs-test.el
@@ -20,11 +20,11 @@
 
 ;;; Commentary:
 
-;; 
+;;
 
 ;; Todo:
 
-;; 
+;;
 
 ;;; Code:
 
@@ -32,7 +32,7 @@
 (require 'ergoemacs-command-loop)
 (require 'ergoemacs-translate)
 
-(eval-when-compile 
+(eval-when-compile
   (require 'cl-lib)
   (require 'ergoemacs-macros))
 
@@ -174,7 +174,7 @@ not using cua or cutting line. I think kill-region is what is meant."
   (let ((ergoemacs-end-of-comment-line t)
         (ergoemacs-back-to-indentation t))
     (with-temp-buffer
-      (emacs-lisp-mode) ; Turn on ergoemacs-mode 
+      (emacs-lisp-mode) ; Turn on ergoemacs-mode
       (insert "(progn\n  (ergoemacs-mode 1)) ; Turn on ergoemacs-mode")
       (goto-char (point-max))
       (call-interactively 'ergoemacs-beginning-of-line-or-what)
@@ -200,7 +200,7 @@ not using cua or cutting line. I think kill-region is what is meant."
       (insert "(progn\n  (ergoemacs-mode 1)) ; Turn on ergoemacs-mode")
       (goto-char (point-max))
       (beginning-of-line)
-      
+
       (call-interactively 'ergoemacs-end-of-line-or-what)
       (should (string= " ; Turn on ergoemacs-mode"
                        (buffer-substring (point) (line-end-position))))
@@ -438,13 +438,13 @@ Part of addressing Issue #147."
   (add-hook 'dired-mode-hook #'ergoemacs-test--dired-hook)
   (dired ergoemacs-dir)
   (should (equal (key-binding (kbd "s s"))
-                 (lookup-key "s" ergoemacs-test--dired-sort-map)))
+                 (lookup-key ergoemacs-test--dired-sort-map "s")))
   (should (equal (key-binding (kbd "s ."))
                  (lookup-key "." ergoemacs-test--dired-sort-map)))
   (should (equal (key-binding (kbd "s t"))
-                 (lookup-key "t" ergoemacs-test--dired-sort-map)))
+                 (lookup-key ergoemacs-test--dired-sort-map "t")))
   (should (equal (key-binding (kbd "s n"))
-                 (lookup-key "n" ergoemacs-test--dired-sort-map)))
+                 (lookup-key ergoemacs-test--dired-sort-map "n")))
   (should (equal (key-binding (kbd "|")) #'dired-sort-menu-toggle-reverse))
   (kill-buffer (current-buffer))
   ;; FIXME: This does not restore `dired-mode-map'!
@@ -466,9 +466,9 @@ Part of addressing Issue #147."
 
   ;; DEL = ^?, doesn't seem to have the issues that RET, ESC, and TAB has.
   (should (string= "DEL" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "DEL" t) 0) :ctl-to-alt)))))
-  
+
   (should (string= "C-DEL" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-DEL" t) 0) :ctl-to-alt)))))
-  
+
   (should (string= "M-DEL" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "C-DEL" t) 0) :ctl-to-alt)))))
 
   ;; RET = ^M
@@ -489,26 +489,26 @@ Part of addressing Issue #147."
   (should (string= "TAB" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "TAB" t) 0) :ctl-to-alt)))))
 
   (should (string= "C-TAB" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-TAB" t) 0) :ctl-to-alt)))))
-  
+
   (should (string= (key-description (kbd "M-TAB")) (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "C-TAB" t) 0) :ctl-to-alt)))))
 
   (cl-letf (((symbol-function 'display-graphic-p) (lambda(&rest _ignore) t)))
     ;; Test M-i -> ^i -> TAB
     (should (string= "<C-i>" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-i" t) 0) :ctl-to-alt)))))
-    
+
     ;; Test M-[ -> ^[ -> ESC
     (should (string= "<C-[>" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-[" t) 0) :ctl-to-alt)))))
-    
+
     ;; Test M-m -> ^m -> RET
     (should (string= "<C-m>" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-m" t) 0) :ctl-to-alt))))))
 
   (cl-letf (((symbol-function 'display-graphic-p) (lambda(&rest _ignore) nil)))
     ;; Test M-i -> ^i -> TAB
     (should (string= "TAB" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-i" t) 0) :ctl-to-alt)))))
-    
+
     ;; Test M-[ -> ^[ -> ESC
     (should (string= "ESC" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-[" t) 0) :ctl-to-alt)))))
-    
+
     ;; Test M-m -> ^m -> RET
     (should (string= "RET" (key-description (vector (ergoemacs-translate--event-mods (elt (read-kbd-macro "M-m" t) 0) :ctl-to-alt)))))))
 
@@ -557,7 +557,7 @@ Part of addressing Issue #147."
   (should (equal 'arg (ergoemacs-command-loop--mouse-command-drop-first '(&rest arg) :rest)))
 
   (should (equal nil (ergoemacs-command-loop--mouse-command-drop-first '(&rest arg) :drop-rest)))
-  
+
   (should (equal nil (ergoemacs-command-loop--mouse-command-drop-first '(&optional arg) t)))
   (should (equal nil (ergoemacs-command-loop--mouse-command-drop-first '(&optional arg))))
   (should (equal nil (ergoemacs-command-loop--mouse-command-drop-first '(&optional arg) :rest)))

--- a/ergoemacs-test.el
+++ b/ergoemacs-test.el
@@ -440,7 +440,7 @@ Part of addressing Issue #147."
   (should (equal (key-binding (kbd "s s"))
                  (lookup-key ergoemacs-test--dired-sort-map "s")))
   (should (equal (key-binding (kbd "s ."))
-                 (lookup-key "." ergoemacs-test--dired-sort-map)))
+                 (lookup-key ergoemacs-test--dired-sort-map ".")))
   (should (equal (key-binding (kbd "s t"))
                  (lookup-key ergoemacs-test--dired-sort-map "t")))
   (should (equal (key-binding (kbd "s n"))

--- a/ergoemacs-test.el
+++ b/ergoemacs-test.el
@@ -1,6 +1,6 @@
-;;; ergoemacs-test.el --- tests for ErgoEmacs issues
+;;; ergoemacs-test.el --- tests for ErgoEmacs issues  -*- lexical-binding: t; -*-
 
-;; Copyright © 2013-2021 Free Software Foundation, Inc.
+;; Copyright © 2013-2023 Free Software Foundation, Inc.
 
 ;; Maintainer: Matthew L. Fidler
 ;; Keywords: convenience
@@ -27,6 +27,10 @@
 ;; 
 
 ;;; Code:
+
+(require 'ergoemacs-functions)
+(require 'ergoemacs-command-loop)
+(require 'ergoemacs-translate)
 
 (eval-when-compile 
   (require 'cl-lib)
@@ -135,8 +139,9 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.")
 (defun ergoemacs-test ()
   "Test ergoemacs issues."
   (interactive)
-  (let ((ret t)
-        (test))
+  (let (;; (ret t)
+        ;; (test)
+        )
     (elp-instrument-package "ergoemacs-")
     (ert "^ergoemacs-test-")
     (call-interactively 'elp-results)))
@@ -174,16 +179,16 @@ not using cua or cutting line. I think kill-region is what is meant."
       (goto-char (point-max))
       (call-interactively 'ergoemacs-beginning-of-line-or-what)
       (should (string= "Turn on ergoemacs-mode"
-                       (buffer-substring (point) (point-at-eol))))
+                       (buffer-substring (point) (line-end-position))))
       (call-interactively 'ergoemacs-beginning-of-line-or-what)
       (should (string= " ; Turn on ergoemacs-mode"
-                       (buffer-substring (point) (point-at-eol))))
+                       (buffer-substring (point) (line-end-position))))
       (call-interactively 'ergoemacs-beginning-of-line-or-what)
       (should (string= "(ergoemacs-mode 1)) ; Turn on ergoemacs-mode"
-                       (buffer-substring (point) (point-at-eol))))
+                       (buffer-substring (point) (line-end-position))))
       (call-interactively 'ergoemacs-beginning-of-line-or-what)
       (should (string= "  (ergoemacs-mode 1)) ; Turn on ergoemacs-mode"
-                       (buffer-substring (point) (point-at-eol)))))))
+                       (buffer-substring (point) (line-end-position)))))))
 
 
 (ert-deftest ergoemacs-test-function-eol-or-what ()
@@ -198,9 +203,9 @@ not using cua or cutting line. I think kill-region is what is meant."
       
       (call-interactively 'ergoemacs-end-of-line-or-what)
       (should (string= " ; Turn on ergoemacs-mode"
-                       (buffer-substring (point) (point-at-eol))))
+                       (buffer-substring (point) (line-end-position))))
       (call-interactively 'ergoemacs-end-of-line-or-what)
-      (should (= (point) (point-at-eol))))))
+      (should (= (point) (line-end-position))))))
 
 (ert-deftest ergoemacs-test-function-unbind-commands-active ()
   "Make sure the unbound keys work"
@@ -243,7 +248,7 @@ See Issue #138."
          (w-file (expand-file-name "global-test" ergoemacs-dir))
          (temp-file (make-temp-file "ergoemacs-test" nil ".el")))
     (setq sk
-          (format "(%s '(lambda() (interactive) (with-temp-file \"%s\" (insert \"Ok\"))))"
+          (format "(%s (lambda() (interactive) (with-temp-file \"%s\" (insert \"Ok\"))))"
                   (cond
                    ((eq ergoemacs 'define-key)
                     (format "define-key global-map (kbd \"%s\") " test-key))
@@ -346,16 +351,15 @@ See Issue #138."
   "Major mode for testing some issues with `ergoemacs-mode'.
 \\{ergoemacs-test-major-mode-map}")
 
-(define-key ergoemacs-test-major-mode-map (kbd "C-s") 'search-forward)
-(define-key ergoemacs-test-major-mode-map (kbd "<f6>") 'search-forward)
-(define-key ergoemacs-test-major-mode-map (kbd "M-s a") 'isearch-forward)
-(define-key ergoemacs-test-major-mode-map (kbd "M-s b") 'isearch-backward)
+(define-key ergoemacs-test-major-mode-map (kbd "C-s") #'search-forward)
+(define-key ergoemacs-test-major-mode-map (kbd "<f6>") #'search-forward)
+(define-key ergoemacs-test-major-mode-map (kbd "M-s a") #'isearch-forward)
+(define-key ergoemacs-test-major-mode-map (kbd "M-s b") #'isearch-backward)
 
-(let ((ergoemacs-is-user-defined-map-change-p t))
+;; (let ((ergoemacs-is-user-defined-map-change-p t))
   (add-hook 'ergoemacs-test-major-mode-hook
-            '(lambda()
-               (interactive)
-               (define-key ergoemacs-test-major-mode-map (kbd "C-w") 'ergoemacs-close-current-buffer))))
+            (lambda()
+              (define-key ergoemacs-test-major-mode-map (kbd "C-w") #'ergoemacs-close-current-buffer))) ;; )
 
 (ert-deftest ergoemacs-test-issue-349 ()
   "Unbind <f6>"
@@ -388,10 +392,12 @@ See Issue #138."
     (when (file-exists-p w-file)
       (delete-file w-file))))
 
+(defvar ergoemacs-use-function-remapping)
+
 (ert-deftest ergoemacs-test-ignore-ctl-w ()
   "Keep user-defined C-w in major-mode `ergoemacs-test-major-mode'.
 Part of addressing Issue #147."
-  (let (ret
+  (let (;; ret
         (ergoemacs-use-function-remapping t))
     (with-temp-buffer
       (ergoemacs-test-major-mode)
@@ -401,55 +407,48 @@ Part of addressing Issue #147."
       ;; The user-defined C-w should not affect kill-region remaps.
       (should (not (eq (key-binding [ergoemacs-remap kill-region]) 'ergoemacs-close-current-buffer))))))
 
+
+(require 'dired)
+
+(defvar ergoemacs-test--dired-sort-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "s"
+      (lambda () "sort by Size"
+        (interactive) (dired-sort-other (concat dired-listing-switches "-AlS --si --time-style long-iso"))))
+    (define-key map "."
+      (lambda () "sort by eXtension"
+        (interactive) (dired-sort-other (concat dired-listing-switches "X"))))
+    (define-key map "t"
+      (lambda () "sort by Time"
+        (interactive) (dired-sort-other (concat dired-listing-switches "t"))))
+    (define-key map "n"
+      (lambda () "sort by Name"
+        (interactive) (dired-sort-other (concat dired-listing-switches ""))))
+    map))
+
+
+(defun ergoemacs-test--dired-hook ()
+  (define-key dired-mode-map "s" ergoemacs-test--dired-sort-map)
+  ;; Use "|", not "r".
+  (define-key dired-mode-map "|" #'dired-sort-menu-toggle-reverse)
+  )
+
 (ert-deftest ergoemacs-test-dired-sort-files ()
   "Test Issue #340"
-  (add-hook 'dired-mode-hook (lambda ()
-                               (interactive)
-                               (make-local-variable  'dired-sort-map)
-                               (setq dired-sort-map (make-sparse-keymap))
-                               (define-key dired-mode-map "s" dired-sort-map)
-                               (define-key dired-sort-map "s"
-                                 '(lambda () "sort by Size"
-                                    (interactive) (dired-sort-other (concat dired-listing-switches "-AlS --si --time-style long-iso"))))
-                               (define-key dired-sort-map "."
-                                 '(lambda () "sort by eXtension"
-                                    (interactive) (dired-sort-other (concat dired-listing-switches "X"))))
-                               (define-key dired-sort-map "t"
-                                 '(lambda () "sort by Time"
-                                    (interactive) (dired-sort-other (concat dired-listing-switches "t"))))
-                               (define-key dired-sort-map "n"
-                                 '(lambda () "sort by Name"
-                                    (interactive) (dired-sort-other (concat dired-listing-switches ""))))
-                               ;; Use "|", not "r".
-                               (define-key dired-mode-map "|" 'dired-sort-menu-toggle-reverse)
-                               ))
+  (add-hook 'dired-mode-hook #'ergoemacs-test--dired-hook)
   (dired ergoemacs-dir)
-  (should (equal (key-binding (kbd "s s")) '(lambda () "sort by Size" (interactive) (dired-sort-other (concat dired-listing-switches "-AlS --si --time-style long-iso")))))
-  (should (equal (key-binding (kbd "s .")) '(lambda () "sort by eXtension" (interactive) (dired-sort-other (concat dired-listing-switches "X")))))
-  (should (equal (key-binding (kbd "s t")) '(lambda () "sort by Time" (interactive) (dired-sort-other (concat dired-listing-switches "t")))))
-  (should (equal (key-binding (kbd "s n")) '(lambda () "sort by Name" (interactive) (dired-sort-other (concat dired-listing-switches "")))))
-  (should (equal (key-binding (kbd "|")) 'dired-sort-menu-toggle-reverse))
+  (should (equal (key-binding (kbd "s s"))
+                 (lookup-key "s" ergoemacs-test--dired-sort-map)))
+  (should (equal (key-binding (kbd "s ."))
+                 (lookup-key "." ergoemacs-test--dired-sort-map)))
+  (should (equal (key-binding (kbd "s t"))
+                 (lookup-key "t" ergoemacs-test--dired-sort-map)))
+  (should (equal (key-binding (kbd "s n"))
+                 (lookup-key "n" ergoemacs-test--dired-sort-map)))
+  (should (equal (key-binding (kbd "|")) #'dired-sort-menu-toggle-reverse))
   (kill-buffer (current-buffer))
-  (remove-hook 'dired-mode-hook (lambda ()
-    (interactive)
-    (make-local-variable  'dired-sort-map)
-    (setq dired-sort-map (make-sparse-keymap))
-    (define-key dired-mode-map "s" dired-sort-map)
-    (define-key dired-sort-map "s"
-      '(lambda () "sort by Size"
-         (interactive) (dired-sort-other (concat dired-listing-switches "-AlS --si --time-style long-iso"))))
-    (define-key dired-sort-map "."
-      '(lambda () "sort by eXtension"
-         (interactive) (dired-sort-other (concat dired-listing-switches "X"))))
-    (define-key dired-sort-map "t"
-      '(lambda () "sort by Time"
-         (interactive) (dired-sort-other (concat dired-listing-switches "t"))))
-    (define-key dired-sort-map "n"
-      '(lambda () "sort by Name"
-         (interactive) (dired-sort-other (concat dired-listing-switches ""))))
-    ;; Use "|", not "r".
-    (define-key dired-mode-map "|" 'dired-sort-menu-toggle-reverse)
-    )))
+  ;; FIXME: This does not restore `dired-mode-map'!
+  (remove-hook 'dired-mode-hook #'ergoemacs-test--dired-hook))
 
 
 (ert-deftest ergoemacs-test-quail-translations ()

--- a/ergoemacs-theme-engine.el
+++ b/ergoemacs-theme-engine.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-theme-engine.el --- Ergoemacs map interface -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-theme-engine.el
 ;; Description:
@@ -135,7 +135,7 @@
     (message "Wrote current ergoemacs bindings to ~/.inputrc")))
 
 ;;;###autoload
-(defalias 'ergoemacs-bash 'ergoemacs-theme-create-bash)
+(defalias 'ergoemacs-bash #'ergoemacs-theme-create-bash)
 
 (defcustom ergoemacs-function-short-names
       '((abort-recursive-edit "abort edit")
@@ -417,8 +417,7 @@ current buffer."
        (setq ergoemacs-command-loop--read-key-prompt ""))))
   (when (arrayp key-list)
     ;; Compatibility with old calling convention.
-    (setq key-list (con
-                    s (list key-list) (if up-event (list up-event))))
+    (setq key-list (cons (list key-list) (if up-event (list up-event))))
     (when buffer
       (let ((raw (if (numberp buffer) (this-single-command-raw-keys) buffer)))
         (setf (cdar (last key-list)) raw)))
@@ -753,7 +752,7 @@ to png files."
 			 "ergoemacs-png-convert" "*ergoemacs-theme-png-convert*"
 			 (nth 1 png-info))
 		ergoemacs-theme--png-last (nth 2 png-info))
-	  (set-process-sentinel process 'ergoemacs-theme--png--process))))))
+	  (set-process-sentinel process #'ergoemacs-theme--png--process))))))
 
 (defun ergoemacs-theme--png (&optional layout full-p reread)
   "Get png file for layout, or create one.

--- a/ergoemacs-themes.el
+++ b/ergoemacs-themes.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-themes.el --- ErgoEmacs keybindings and themes -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021 Free Software Foundation, Inc.
+;; Copyright © 2013-2023 Free Software Foundation, Inc.
 
 ;; Maintainer: Matthew L. Fidler
 ;; Authors: Matthew L. Fidler, Xah Lee, Drew Adams
@@ -30,15 +30,15 @@
 (require 'ibuffer)
 
 (defun ergoemacs-global-set-key (key command &optional extra-keys)
-  "Translates KEY from a 'us' layout to the current layout.
+  "Translates KEY from a `us' layout to the current layout.
 This also sets the binding as a global binding as COMMAND.
 
-For example, if your layout is 'us', the command
+For example, if your layout is `us', the command
 
-  (ergoemaces-global-set-key (kbd \"M-k\") 'next-line)
+  (ergoemacs-global-set-key (kbd \"M-k\") #\\='next-line)
 
-will bind 'Meta-k' to next-line.  If your layout is 'colemak', it will bind
-'Meta-e' to next-line.
+will bind `Meta-k' to next-line.  If your layout is `colemak', it will bind
+`Meta-e' to next-line.
 
 EXTRA-KEYS are untranslated keys that are appended."
   (if extra-keys
@@ -51,16 +51,16 @@ EXTRA-KEYS are untranslated keys that are appended."
                     command)))
 
 (defun ergoemacs-define-key (map key command &optional extra-keys)
-  "Translates KEY from a 'us' layout to the current layout.
+  "Translates KEY from a `us' layout to the current layout.
 
 In this case,  the key is then  defined in the MAP to run COMMAND.
 
-For example, if your layout is 'us', the command
+For example, if your layout is `us', the command
 
-  (ergoemacs-define-key keymap (kbd \"M-k\") 'next-line)
+  (ergoemacs-define-key keymap (kbd \"M-k\") #\\='next-line)
 
-will bind 'Meta-k' to next-line.  If your layout is 'colemak', it will bind
-'Meta-e' to next-line.
+will bind `Meta-k' to next-line.  If your layout is `colemak', it will bind
+`Meta-e' to next-line.
 
 EXTRA-KEYS are untranslated keys that are appended."
   (if extra-keys

--- a/ergoemacs-translate.el
+++ b/ergoemacs-translate.el
@@ -1,6 +1,6 @@
 ;;; ergoemacs-translate.el --- Keyboard translation functions -*- lexical-binding: t -*-
 
-;; Copyright © 2013-2021  Free Software Foundation, Inc.
+;; Copyright © 2013-2023  Free Software Foundation, Inc.
 
 ;; Filename: ergoemacs-translate.el
 ;; Description: 
@@ -122,7 +122,7 @@
       hash-f-t)))
 
 (defun ergoemacs-translate--emacs-shift (key-seq &optional modifier prefix)
-  "Uses emacs style shift-translation: M-Q becomes M-q.
+  "Uses Emacs style shift-translation: M-Q becomes M-q.
 
 KEY-SEQ must be a vector.  If there is no need to shift-translate
 the key sequence return nil.
@@ -131,7 +131,7 @@ Optionally you can change how this function behaves.
 
 Instead of translating the shifted key to the unshifted key, you
 can remove another modifier.  For example if you wanted to
-convert C-M-a to C-a, you could use 'meta as the MODIFIER
+convert C-M-a to C-a, you could use `meta' as the MODIFIER
 argument to remove the M- modifier.
 
 The PREFIX argument can add a key before the key where the
@@ -247,7 +247,7 @@ This will shift translate Alt+# to Alt+3."
 	       (not (eq (event-convert-list (list 'shift (setq basic (event-basic-type (aref key 0)))))
 			(ergoemacs-translate--event-convert-list (list 'ergoemacs-shift basic)))))
       (setq ergoemacs-translate--define-key-if-defined-p nil
-            ergoemacs-translate--define-key-replacement-function 'ergoemacs-command-loop--shift-translate)
+            ergoemacs-translate--define-key-replacement-function #'ergoemacs-command-loop--shift-translate)
       (vector (ergoemacs-translate--event-convert-list (append modifiers (list 'ergoemacs-shift basic)))))))
 
 (defun ergoemacs-translate--ergoemacs-timeout (key)
@@ -266,7 +266,7 @@ seleceted (instead of copying the text)."
 			(memq 'ergoemacs-shift modifiers))))
       (setq basic (ergoemacs-translate--event-basic-type (aref key 0))
 	    ergoemacs-translate--define-key-if-defined-p nil
-            ergoemacs-translate--define-key-replacement-function 'ergoemacs-command-loop--shift-timeout)
+            ergoemacs-translate--define-key-replacement-function #'ergoemacs-command-loop--shift-timeout)
       (vector (ergoemacs-translate--event-convert-list (append modifiers (list 'shift basic)))))))
 
 (defun ergoemacs-translate--to-string (key)
@@ -355,8 +355,8 @@ This uses `ergoemacs-translate--apply-key'"
 (defun ergoemacs-translate--event-modifiers (event &optional layout)
   "Return a list of symbols representing the modifier keys in event EVENT.
 This is different than `event-modifiers' in two ways:
-- Symbol keys like # will return 'ergoemacs-shift for a QWERTY keyboard.
-- Special keys like C-RET will return 'ergoemacs-control
+- Symbol keys like # will return `ergoemacs-shift' for a QWERTY keyboard.
+- Special keys like C-RET will return `ergoemacs-control'
 LAYOUT is the keyboard layout."
   (let ((modifiers (event-modifiers event))
 	tmp 
@@ -407,7 +407,7 @@ MODIFIERS is the precalculated modifiers from
 `ergoemacs-translate--event-modifiers'."
   (if (vectorp event)
       (progn
-        (apply 'vector (mapcar (lambda(x) (ergoemacs-translate--event-layout x layout-to layout-from basic modifiers)) event)))
+        (apply #'vector (mapcar (lambda(x) (ergoemacs-translate--event-layout x layout-to layout-from basic modifiers)) event)))
     (let* ((basic (or basic (ergoemacs-translate--event-basic-type event layout-from)))
            (modifiers (or modifiers (ergoemacs-translate--event-modifiers event layout-from)))
            new-modifiers
@@ -450,9 +450,9 @@ This also translates <C-i> to ?i, <C-m> to ?m <C-[> to ?[
 (defun ergoemacs-translate--event-convert-list (list &optional layout)
    "Convert the event description LIST to an event type.
 This is different than `event-convert-list' because:
- -  '(shift ?3) or '(ergoemacs-shift ?3) produces ?# on a QWERTY LAYOUT.
- -  '(ergoemacs-control control ?m) produces C-RET
- -  '(ergoemacs-gui control ?m) produces <C-m>. this applies for ?i and ?[ as well.
+ -  (shift ?3) or (ergoemacs-shift ?3) produces ?# on a QWERTY LAYOUT.
+ -  (ergoemacs-control control ?m) produces C-RET
+ -  (ergoemacs-gui control ?m) produces <C-m>. this applies for ?i and ?[ as well.
  - Mouse events allow click modifiers"
   (let ((cur-list list)
         elt
@@ -759,9 +759,9 @@ When NAME is a symbol, setup the translation function for the symbol."
       (dolist (type '("-universal-argument" "-negative-argument"
                       "-digit-argument" "-modal"))
 	(fset (intern (concat "ergoemacs-translate--" name-str type))
-	      'ergoemacs-translate--setup-command-loop)
+	      #'ergoemacs-translate--setup-command-loop)
 	(fset (intern (concat "ergoemacs-" name-str type))
-	      'ergoemacs-translate--setup-command-loop)
+	      #'ergoemacs-translate--setup-command-loop)
 	(when (string= type "-universal-argument")
 	  (cl-pushnew (intern (concat "ergoemacs-" name-str type)) ergoemacs-command-loop--universal-functions)
 	  (cl-pushnew (intern (concat "ergoemacs-translate--" name-str type)) ergoemacs-command-loop--universal-functions))))))
@@ -1100,10 +1100,10 @@ This takes into consideration the modal state of `ergoemacs-mode'."
 
 (defun ergoemacs-translate--ahk-ini (&optional all-layouts all-themes)
   "Creates the ini file used with the autohotkey script."
-  (let ((layouts (or (and all-layouts (sort (ergoemacs-layouts--list) 'string<))
+  (let ((layouts (or (and all-layouts (sort (ergoemacs-layouts--list) #'string<))
                      (and (eq (ergoemacs :layout) 'ergoemacs-layout-us) (list "us"))
                      (list "us" ergoemacs-keyboard-layout)))
-        (themes (or (and all-themes (sort (ergoemacs-theme--list) 'string<))
+        (themes (or (and all-themes (sort (ergoemacs-theme--list) #'string<))
                     (list ergoemacs-theme)))
         (original-layout ergoemacs-keyboard-layout)
         (original-theme ergoemacs-theme)


### PR DESCRIPTION
The original goal was to remove the remaining use of `defadvice` (in `ergoemacs-advice`) but that proved to be dead code, and then I checked the resulting compiler warnings, etc...

Prefer #' to quote function names.
Remove dummy `unwind-protect` without any unwind forms. Avoid deprecated `point-at-bol/eol`.
Fix some uses of ' in docstrings.

Also fix a misunderstanding: `inhibit-point-motion-hooks` is not used by the command loop's point adjustment code, it's only used by the low-level point-motion hooks (those implemented deep inside the C code of `goto-char` and friends, and which have been deprecated since Emacs-25 because running arbitrary ELisp code from within `goto-char` is too problematic).

* ergoemacs-macros.el (ergoemacs-save-buffer-state): Make it an obsolete alias of `with-silent-modifications`.  Update all callers. (ergoemacs-translation): Simplify `kb` initialization and remove unneeded `progn`.
(ergoemacs-advice): Delete unused macro.

* ergoemacs-theme-engine.el (ergoemacs-describe-key): Fix typo.

* ergoemacs-layouts.el: Fix typo in the `lexical-binding` cookie.
(ergoemacs-layout--regexp): Remove unused var `reg`.
(ergoemacs-layout-describe): Remove unused vars `alias` and `pt`.

* ergoemacs-test.el: Require packages, to reduce compiler warnings. (<toplevel>): Don't quote `lambda`; don't let-bind unused `ergoemacs-is-user-defined-map-change-p`; and don't specify `interactive` for a function only used on a hook.
(ergoemacs-use-function-remapping): Declare var as dynamic. (ergoemacs-test): Remove unused var `ret` and `test`. (ergoemacs-test-ignore-ctl-w): Remove unused var `ret`. (ergoemacs-test--dired-sort-map): New var extracted from `ergoemacs-test-dired-sort-files`.
(ergoemacs-test--dired-hook): New function extracted from `ergoemacs-test-dired-sort-files`.
(ergoemacs-test-dired-sort-files): Use them to simplify the code by reducing duplication.

* ergoemacs-mode.el (ergoemacs-mode): Remove spurious `nil` arg before the keyword arguments.
(ergoemacs-setup-override-keymap): Don't abuse `add-hook` on a non-hook.
(ergoemacs-remove-override-keymap): Don't abuse `remove-hook` on a non-hook.

* ergoemacs-mapkeymap.el (ergoemacs-map-keymap): Remove unused/constant var `calc-parent-p`.

* ergoemacs-map.el (ergoemacs-map--alist): Merge two `prog1`.

* ergoemacs-functions.el (ergoemacs-delete-char): Delete one of the two duplicate definitions.
(ergoemacs-run-clean): Remove unused/constant `rm-batch` variable and associated dead code.  Use `derived-mode-p`.
(ergoemacs-use-beginning-or-end-of-line-only): Fix wrong `const` format in the `:type`.
(ergoemacs-beginning-of-line-or-what): `beginning-of-buffer` is for interactive use only.
(ergoemacs-maximum-number-of-file-to-open): Fix typo in `:type`. (ergoemacs-camelize-method): Don't quote `lambda`.

* ergoemacs-command-loop.el (ergoemacs-command-loop--decode-event): Comment out unused var `timeout-key`.
(ergoemacs-command-loop--point-motion-hooks): Don't test `inhibit-point-motion-hooks`.
(ergoemacs-command-loop--internal): Don't set
`inhibit-point-motion-hooks`.

* ergoemacs-advice.el: Require `ergoemacs-command-loop`.
(ergoemacs--temporary-disable): Declare var as dynamic.